### PR TITLE
[FIX] Symbol addresses with ASLR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make CFLAGS+="-g -finstrument-functions -O0"
     ```bash
     bash $ cat run.sh
     #!/bin/sh
-    export LD_PRELOAD=/path/to/ftracer.so
+    export LD_PRELOAD=/path/to/ftracer.so:libdl.so
 
     ./yourapp
     ```

--- a/example/c/run.sh
+++ b/example/c/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export LD_PRELOAD=../../src/ftracer.so
+export LD_PRELOAD=../../src/ftracer.so:libdl.so
 
 ./test

--- a/example/coredump/run.sh
+++ b/example/coredump/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export LD_PRELOAD=../../src/ftracer.so
+export LD_PRELOAD=../../src/ftracer.so:libdl.so
 
 ./test

--- a/example/cpp/run.sh
+++ b/example/cpp/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export LD_PRELOAD=../../src/ftracer.so
+export LD_PRELOAD=../../src/ftracer.so:libdl.so
 
 ./test

--- a/example/cpp_exception/run.sh
+++ b/example/cpp_exception/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export LD_PRELOAD=../../src/ftracer.so
+export LD_PRELOAD=../../src/ftracer.so:libdl.so
 
 ./test

--- a/example/longjump/run.sh
+++ b/example/longjump/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-export LD_PRELOAD=../../src/ftracer.so
+export LD_PRELOAD=../../src/ftracer.so:libdl.so
 
 ./test

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 all:
-	gcc -Wall -g -fPIC -shared -o ftracer.so ftracer.c
+	gcc -Wall -g -fPIC -ldl -shared -o ftracer.so ftracer.c
 
 clean:
 	rm -f ftracer.so

--- a/tools/gen_report.sh
+++ b/tools/gen_report.sh
@@ -2,6 +2,8 @@
 
 #set -x
 
+curdir="$(cd "$(dirname "$0")"; pwd)"
+
 # user input args
 exe=
 trace_file=
@@ -22,7 +24,7 @@ stage_file=trace_stage_data
 report_file=trace_report
 html_report_folder=html
 index_file=trace_thread_index.txt
-template_folder=./template
+template_folder="${curdir}/template"
 
 function signal_handler()
 {
@@ -219,7 +221,7 @@ function generate_report()
         args=$args" -F $output_format"
     fi
 
-    ./formatter.py -f $input $args > $output
+    "${curdir}/formatter.py" -f $input $args > $output
     if [ $? != 0 ]; then
         echo "Error occurred during formatter.py"
         cat $output
@@ -304,7 +306,7 @@ function translate_multi_process()
 
         debug_print "partition$i: start=$start lines=$partition_size total_size=$size"
         # for every thread, it will read its partition lines
-        tail -n +$start $input | head -$partition_size | awk -F '|' '{print $4, $5}' | xargs addr2line -e $exe -f -C | awk '{if (NR%4==0) {print $0} else {printf "%s|", $0}}' | awk -F '|' '{printf "%s|%s|%s\n", $1, $2, $4}' | ./trans_status.awk -vstatus_file=$status_file -vsize=$partition_size > $partition &
+        tail -n +$start $input | head -$partition_size | awk -F '|' '{print $4, $5}' | xargs addr2line -e $exe -f -C | awk '{if (NR%4==0) {print $0} else {printf "%s|", $0}}' | awk -F '|' '{printf "%s|%s|%s\n", $1, $2, $4}' | "${curdir}/trans_status.awk" -vstatus_file=$status_file -vsize=$partition_size > $partition &
     done
 
     # wait until all the sub jobs finish
@@ -385,7 +387,7 @@ do
     # 3. filter the raw data, get the pure data for next step
     thread_pure_data=$output_folder/$pure_data_file.$threadid
     debug_print "phase 3: generate pure data($thread_pure_data)"
-    ./filter.py -f $thread_raw_data > $thread_pure_data
+    "${curdir}/filter.py" -f $thread_raw_data > $thread_pure_data
     check_and_exit
 
     # 4. translate addrs to the function name and caller information


### PR DESCRIPTION
On modern platforms, binaries are compiled with PIE (Position Independent Executable) feature activated. Also, on recent kernels, the Address Space Layout Randomization (ASLR) is activated.
Thus, the symbol adresses passed to instrumentation functions are not the real symbol adresses in the binaries and the lookup done by `addr2line` will fail.

This change removes the offset from the adresses.

As a freebie, launching `gen_report.sh` from any location has been fixed.

As a side note, the setting up of the trace from a function address will not work.